### PR TITLE
Read GCMID from env var

### DIFF
--- a/deploy/upstart.tpl.conf
+++ b/deploy/upstart.tpl.conf
@@ -7,5 +7,6 @@ chdir %(install_dir)s/src
 script
   . /etc/environment
   export PG_CONNSTR
+  export GCM_API_KEY
   exec python server.py %(port)s
 end script

--- a/src/api/views.py
+++ b/src/api/views.py
@@ -148,7 +148,7 @@ def get_profile():
 @api.route('/gcm-message/', methods=['POST'])
 def gcm_message():
     if request.form.get('message'):
-        gcmClient = GCMClient(api_key='AIzaSyDutdDVwmgkPeVIxITVhN0sn_Q66iQ-JIA')
+        gcmClient = GCMClient(api_key=os.environ.get('GCM_API_KEY'))
         alert = request.form.get('message')
         # TODO: obtain this gcm_id (it can be a list of GCM IDs) from the DB
         # gcm_id = 'dgS_vYVnLcU:APA91bHI2sXIy8uIATbPrTIwXu9oWc_rVJ8a4ejjdwhub9ZUGi6LlMgVXT6uOF3_XnMzTO1xAvoqmd5HpKg1n2g0UJ51V1Qq8OkwaiR_aUB-2e9X-s4sDyjKUt_MlakxgfKJZSzHeqD6'


### PR DESCRIPTION
@ani12321 @aziflaj Deployed already.

Serveri run-et nga upstart (qe gjithashtu kujdeset qe ta beje restart nqs vdes) me nje environment qe krijohet nga upstart. Gjithe environment variables duhen bere `export` te `deploy/upstart.tpl.conf`. Ky file ne server upload-ohet ne `/etc/init/tiranacode.conf`

Sa here qe kemi ndryshime te ky file, nuk mjafton `fab redeploy`. Para `fab redeploy` duhet te bejme `fab install_service` qe te uploadohet `deploy/upstart.tpl.conf` ne `/etc/init/tiranacode.conf`
